### PR TITLE
Updated installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-This plugin is not available as a Gem.
+    gem install fluentd-plugin-graylog
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# [GrayLog](http://graylog.org) plugin for [Fluentd](http://fluentd.org)
+# [Graylog][graylog] plugin for [Fluentd][fluentd]
 
 [![Build Status](https://circleci.com/gh/FundingCircle/fluent-plugin-graylog/tree/master.svg?style=shield&circle-token=532f50099abc19d39f00c89faa39e4d85de12788)](https://circleci.com/gh/FundingCircle/fluent-plugin-graylog/tree/master)
 [![Code Climate](https://codeclimate.com/github/FundingCircle/fluent-plugin-graylog/badges/gpa.svg)](https://codeclimate.com/github/FundingCircle/fluent-plugin-graylog)
 [![Test Coverage](https://codeclimate.com/github/FundingCircle/fluent-plugin-graylog/badges/coverage.svg)](https://codeclimate.com/github/FundingCircle/fluent-plugin-graylog/coverage)
 
-[fluentd](http://fluentd.org) output plugin for GrayLog.
+A [Fluentd](http://fluentd.org) output plugin for [Graylog][graylog].
+
+[fluentd]: http://fluentd.org
+[graylog]: http://graylog.org
 
 ## Installation
 
@@ -28,6 +31,7 @@ Example
 ```
 
 ## License
+
 Copyright © 2015 Funding Circle Ltd.
 
 Distributed under the BSD 3-Clause License.

--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Funding Circle']
   spec.email         = ['engineering@fundingcircle.com']
 
-  spec.summary       = 'GrayLog output plugin for Fluentd'
-  spec.description   = 'Send logging information in JSON format via TCP to an instance of GrayLog'
+  spec.summary       = 'Graylog output plugin for Fluentd'
+  spec.description   = 'Send logging information in JSON format via TCP to an instance of Graylog'
   spec.license       = 'BSD-3-Clause'
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(spec|features)/}) }


### PR DESCRIPTION
:information_desk_person: Now that this gem [is available on RubyGems](fluent-plugin-graylog), the installation instructions need to be updated.

Closes #12 