### PR TITLE
Update version to 1.0.1

### DIFF
--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-graylog'
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ['Funding Circle']
   spec.email         = ['engineering@fundingcircle.com']
 


### PR DESCRIPTION
:information_desk_person: This version temporarily replaces the accidentally (:blush:) yanked v1.0.0 gem.