### PR TITLE
replacing JSON encoder with Yajl

### DIFF
--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_runtime_dependency 'fluentd', '~> 0.12'
+  spec.add_runtime_dependency 'yajl', '~> 0.3'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'

--- a/lib/fluent/plugin/out_graylog.rb
+++ b/lib/fluent/plugin/out_graylog.rb
@@ -35,7 +35,7 @@ module Fluent
     def write(chunk)
       records = []
       chunk.msgpack_each do |record|
-        records.push JSON.dump(record) + "\0" # Message delimited by null char
+        records.push Yajl.dump(record) + "\0" # Message delimited by null char
       end
 
       log.debug 'establishing connection with GrayLog'


### PR DESCRIPTION
To avoid character encoding problems with malformed UTF-8:

  "[fluentd] ... failed to flush the buffer. ...
  error_class="JSON::GeneratorError" error="source sequence is
  illegal/malformed utf-8" ..."

(idea for this patch comes from
https://github.com/uken/fluent-plugin-elasticsearch/issues/19)