### PR TITLE
Fix Rubocop cop deprecation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 Style/Documentation:
   Enabled: false
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
   Enabled: true
   EnforcedStyleForMultiline: comma

--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.3'
   spec.add_development_dependency 'test-unit', '~> 3.1'
   spec.add_development_dependency 'pry', '~> 0.10'
-  spec.add_development_dependency 'rubocop', '~> 0.32'
+  spec.add_development_dependency 'rubocop', '0.38.0'
 end
 # rubocop:enable Metrics/LineLength

--- a/lib/fluent/plugin/out_graylog.rb
+++ b/lib/fluent/plugin/out_graylog.rb
@@ -15,7 +15,7 @@ module Fluent
 
     def configure(conf)
       super
-      fail ConfigError, "'host' parameter required" unless conf.key?('host')
+      raise ConfigError, "'host' parameter required" unless conf.key?('host')
     end
 
     def start


### PR DESCRIPTION
Builds are failing due to the following Rubocop error.

```
Error: The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead.
```