### PR TITLE
Lock fluentd dependency to v0.12.x stream

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'codeclimate-test-reporter', require: false
+  gem 'simplecov', require: false
 end
 
 gemspec

--- a/circle.yml
+++ b/circle.yml
@@ -6,3 +6,5 @@ test:
   override:
     - rvm-exec 1.9.3-p392 bundle exec rake
     - rvm-exec 2.2.2 bundle exec rake
+  post:
+    - rvm-exec 2.2.2 bundle exec codeclimate-test-reporter

--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'fluent-plugin-graylog'
-  spec.version       = '1.0.1'
+  spec.version       = '1.0.2'
   spec.authors       = ['Funding Circle']
   spec.email         = ['engineering@fundingcircle.com']
 

--- a/fluent-plugin-graylog.gemspec
+++ b/fluent-plugin-graylog.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_runtime_dependency 'fluentd', '~> 0.12'
+  spec.add_runtime_dependency 'fluentd', '~> 0.12.36'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.3'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start if ENV.fetch('CODECLIMATE_REPO_TOKEN', nil)
+require 'simplecov'
+SimpleCov.start if ENV.fetch('CODECLIMATE_REPO_TOKEN', nil)
 
 require 'pry'
 


### PR DESCRIPTION
💁  The interface for the fluentd gem changed in the 0.14.x version stream. Until these changes are accommodated, we need to lock to a working version. These changes add a pessimistic lock to 0.12.x.